### PR TITLE
build android apk  in ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: '19'
+          distribution: 'temurin'
           cache: 'gradle'
 
       - name: Validate Gradle Wrapper

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,50 @@
+name: Build
+
+on:
+  push:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build Android Application (.apk)
+        run: yarn release:android
+
+      - name: List the .apks compiled
+        run: ls ./android/app/build/outputs/apk/release/ -hal
+
+      - name: Rename the .apk to the tag version
+        run: mv ./android/app/build/outputs/apk/release/app-universal-release.apk ./android/app/build/outputs/apk/release/pantra_${{ github.ref_name }}.apk
+
+      # todo: sign apks to verify authenticity
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: app
+          path: ./android/app/build/outputs/apk/release
+          retention-days: 3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '11'
-          distribution: 'adopts'
+          distribution: 'adopt'
           cache: 'gradle'
 
       - name: Validate Gradle Wrapper

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: '11'
+          distribution: 'adopts'
           cache: 'gradle'
 
       - name: Validate Gradle Wrapper

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "postinstall": "patch-package",
     "assets": "npx react-native-asset",
     "android": "react-native run-android",
+    "release:android": "cd android && ./gradlew assembleRelease",
     "ios:15": "react-native start --port 8089 --simulator \"iPhone 15 Pro Max\"",
     "setup:android": "yarn && cd android && ./gradlew clean && npx react-native start",
     "setup:android-tcp": "adb reverse tcp:8081 tcp:8081 && yarn react-native run-android",


### PR DESCRIPTION
- Adds a workflow that builds android apks every time **a push** is made to this repository.
- The apk(s) are added as artifacts to the workflow run. It can be modified to just build whenever `tags` are pushed -- new release.
